### PR TITLE
Add support for texlive extension

### DIFF
--- a/org.lamport.tla.toolbox.yml
+++ b/org.lamport.tla.toolbox.yml
@@ -4,6 +4,14 @@ runtime-version: '19.08'
 sdk: org.freedesktop.Sdk
 command: tlatoolbox
 
+add-extensions:
+  org.freedesktop.Sdk.Extension.texlive:
+    directory: texlive
+    subdirectories: true
+    no-autodownload: true
+    autodelete: true
+    version: "19.08"
+
 finish-args:
   - --share=ipc
   - --socket=x11
@@ -11,6 +19,7 @@ finish-args:
   - --share=network
   - --device=dri
   - --filesystem=home
+  - --env=PATH=/app/bin:/app/texlive/bin:/app/texlive/bin/x86_64-linux:/usr/bin/
 
 modules:
 
@@ -40,7 +49,7 @@ modules:
 
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/TLA/ /app/bin/
+      - mkdir -p /app/TLA/ /app/bin/ /app/texlive
       - cp -a * /app/TLA/
       - ln -s /app/TLA/toolbox /app/bin/tlatoolbox
       - install -Dm644 org.lamport.tla.toolbox.desktop /app/share/applications/org.lamport.tla.toolbox.desktop


### PR DESCRIPTION
If texlive flatpak is installed, pdflatex is available at /app/texlive/bin/x86_64-linux/pdflatex