### PR TITLE
Bump runtime to 22.08

### DIFF
--- a/org.lamport.tla.toolbox.yml
+++ b/org.lamport.tla.toolbox.yml
@@ -32,11 +32,6 @@ modules:
         url: https://github.com/tlaplus/tlaplus/releases/download/v1.7.1/TLAToolbox-1.7.1-linux.gtk.x86_64.zip
         sha256: 108af33356211ec276864877aed83be953099f08bb09c6aea27778113f80fefa
         size: 182043677
-        x-checker-data:
-          type: html
-          url: https://api.github.com/repos/tlaplus/tlaplus/releases/latest
-          version-pattern: https://github.com/tlaplus/tlaplus/releases/tag/v(\d\.\d\.\d)
-          url-template: https://github.com/tlaplus/tlaplus/releases/download/v$version/TLAToolbox-$version-linux.gtk.x86_64.zip
       # Desktop file.
       - type: file
         path: org.lamport.tla.toolbox.desktop

--- a/org.lamport.tla.toolbox.yml
+++ b/org.lamport.tla.toolbox.yml
@@ -1,6 +1,6 @@
 app-id: org.lamport.tla.toolbox
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: tlatoolbox
 
@@ -10,7 +10,7 @@ add-extensions:
     subdirectories: true
     no-autodownload: true
     autodelete: true
-    version: "19.08"
+    version: "22.08"
 
 finish-args:
   - --share=ipc


### PR DESCRIPTION
<del>I took the release date from the tag creation date https://github.com/tlaplus/tlaplus/releases/tag/v1.8.0 I think it has the wrong release date on Github for 1.8.0 as it says 07 Dec 2020 but 1.7.2 was on 03 Feb 2022</del>

Ping @jesmg, please review, when you find time, thanks!